### PR TITLE
block render update

### DIFF
--- a/CommonProxy.java
+++ b/CommonProxy.java
@@ -1,6 +1,7 @@
 package wa;
 
 import cpw.mods.fml.common.network.IGuiHandler;
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.stats.Achievement;
 import net.minecraft.tileentity.TileEntity;
@@ -34,7 +35,10 @@ public class CommonProxy implements IGuiHandler {
 
 	public void init() {
 		// TODO 自動生成されたメソッド・スタブ
-
+		
+		// defeatedcrow追加物
+		GameRegistry.registerTileEntity(TileEntityZabuton.class, "tileentityZabuton");
+		GameRegistry.registerTileEntity(TileEntityKoto.class, "tileentityKoto");
 	}
 
 	public World getClientWorld() {

--- a/EntityZabuton.java
+++ b/EntityZabuton.java
@@ -1,0 +1,212 @@
+package wa;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import wa.block.Blocks;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.EntityDamageSource;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+
+public class EntityZabuton extends Entity {
+	
+	protected float mountHeight = 0.0F;
+
+	public EntityZabuton(World world) {
+		super(world);
+		this.preventEntitySpawning = true;
+        this.setSize(0.5F, 0.125F);
+        this.yOffset = mountHeight;
+	}
+	
+	public EntityZabuton(World par1World, double par2, double par4, double par6)
+    {
+        this(par1World);
+        this.setPosition(par2, par4 + (double)this.yOffset, par6);
+        this.motionX = 0.0D;
+        this.motionY = 0.0D;
+        this.motionZ = 0.0D;
+        this.prevPosX = par2;
+        this.prevPosY = par4;
+        this.prevPosZ = par6;
+        this.rotationYaw = 0.0F;
+    }
+	
+	public boolean attackEntityFrom(DamageSource par1DamageSource, float par2)
+    {
+        if (this.isEntityInvulnerable())
+        {
+            return false;
+        }
+        else if (!this.worldObj.isRemote && !this.isDead)
+        {
+        	this.setBeenAttacked();
+        	if (par1DamageSource instanceof EntityDamageSource)
+            {
+                Entity by = ((EntityDamageSource)par1DamageSource).getEntity();
+                if (by != null && by instanceof EntityPlayer)
+                {
+                	int x = MathHelper.floor_double(posX);
+                	int y = MathHelper.floor_double(posY);
+                	int z = MathHelper.floor_double(posZ);
+                	Block block = worldObj.getBlock(x, y, z);
+                	
+                	if (block != null && block == Blocks.zabuton && worldObj.setBlockToAir(x, y, z)) {
+            			
+            			if (this.riddenByEntity != null)
+                        {
+                            this.riddenByEntity.mountEntity(this);
+                        }
+            			
+            			this.setDead();
+            			return true;
+            		}
+                }
+            }
+        }
+        return false;
+    }
+
+	@Override
+    protected boolean canTriggerWalking()
+    {
+        return false;
+    }
+
+	@Override
+	protected void entityInit() {}
+	
+	@Override
+    public AxisAlignedBB getCollisionBox(Entity par1Entity)
+    {
+        return null;
+    }
+
+    @Override
+    public AxisAlignedBB getBoundingBox()
+    {
+        return this.boundingBox;
+    }
+
+    @Override
+    public boolean canBePushed()
+    {
+        return false;
+    }
+    
+    @Override
+    public boolean canBeCollidedWith()
+    {
+        return !this.isDead;
+    }
+    
+    @SideOnly(Side.CLIENT)
+    public float getShadowSize()
+    {
+        return 0.0F;
+    }
+    
+    @Override
+    public void onUpdate()
+    {
+    	super.onUpdate();
+    	
+    	if (worldObj.isRemote)
+    	{
+//    		this.worldObj.spawnParticle("crit", this.posX, this.posY + 1, this.posZ, this.motionX, this.motionY + 0.2D, this.motionZ);
+    	}
+    	else
+    	{
+        	int x = MathHelper.floor_double(posX);
+        	int y = MathHelper.floor_double(posY);
+        	int z = MathHelper.floor_double(posZ);
+        	Block block = worldObj.getBlock(x, y, z);
+        	
+        	if (block == null || block.isAir(worldObj, x, y, z) || !worldObj.isAirBlock(x, y + 1, z))
+        	{
+        		Logger logger = LogManager.getLogger("Wa");
+        		logger.info("dead.");
+        		this.setDead();
+        	}
+        	else
+        	{
+        		if (block == Blocks.zabuton)
+        		{
+        			int size = worldObj.getBlockMetadata(x, y, z) & 7;
+        			float f = 0.125F * (size + 1);
+        			if (mountHeight != f)
+        			{
+        				setMountHeight(f);
+        			}
+        		}
+        	}
+    	}
+    }
+
+    @Override
+	protected void readEntityFromNBT(NBTTagCompound nbt) {
+    	mountHeight = nbt.getFloat("mount");
+    }
+
+	@Override
+	protected void writeEntityToNBT(NBTTagCompound nbt) {
+		nbt.setFloat("mount", mountHeight);
+	}
+	
+	// 騎乗位置調整
+	
+	protected float getMountHeight()
+	{
+		return mountHeight;
+	}
+	
+	protected void setMountHeight(float f)
+	{
+		mountHeight = f;
+	}
+	
+	@Override
+    public double getMountedYOffset()
+    {
+        return (double)getMountHeight() - 0.125D + 0.06000001192092896D;
+    }
+	
+	@Override
+    public boolean interactFirst(EntityPlayer par1EntityPlayer)
+    {
+		if (this.riddenByEntity != null && this.riddenByEntity instanceof EntityPlayer && this.riddenByEntity != par1EntityPlayer)
+        {
+            return true;
+        }
+		else
+		{
+			ItemStack item = par1EntityPlayer.getCurrentEquippedItem();
+			
+			if (item == null || item.getItem() == null)
+			{
+	            if (!this.worldObj.isRemote)
+	            {
+	                par1EntityPlayer.mountEntity(this);
+	            }
+
+	            return true;
+	        }
+	        else
+	        {
+	        	int x = MathHelper.floor_double(posX);
+	        	int y = MathHelper.floor_double(posY);
+	        	int z = MathHelper.floor_double(posZ);
+	        	return item.getItem().onItemUse(item, par1EntityPlayer, worldObj, x, y, z, 0, 0.5F, mountHeight, 0.5F);
+	        }
+		}
+    }
+}

--- a/ItemSlabBase.java
+++ b/ItemSlabBase.java
@@ -1,0 +1,147 @@
+package wa;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import wa.block.BlockSlabBase;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockSlab;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+/**
+ * バニラのItemSlabが使いにくくて可読性もよろしくないので作成。
+ * 独自に作るデメリットは発生すると思う
+ * @author defeatedcrow
+ */
+public abstract class ItemSlabBase extends ItemBlock
+{
+    public ItemSlabBase(Block block)
+    {
+        super(block);
+        this.setMaxDamage(0);
+        this.setHasSubtypes(true);
+    }
+    
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getIconFromDamage(int meta)
+    {
+        return Block.getBlockFromItem(this).getIcon(1, meta);
+    }
+
+    @Override
+    public int getMetadata(int meta)
+    {
+        return meta;
+    }
+    
+    @Override
+    public String getUnlocalizedName(ItemStack item)
+    {
+        return getHalf().getUnlocalizedName() + "_" + item.getItemDamage();
+    }
+    
+    @Override
+    public boolean onItemUse(ItemStack item, EntityPlayer player, World world, int x, int y, int z, int side, float fx, float fy, float fz)
+    {
+    	if (item == null || Block.getBlockFromItem(item.getItem()).isAir(world, x, y, z))
+        {
+            return false;
+        }
+    	else if (getDouble() == null) //ダブルにならないものもある
+    	{
+    		return super.onItemUse(item, player, world, x, y, z, side, fx, fy, fz);
+    	}
+    	else if (item.stackSize == 0)
+        {
+            return false;
+        }
+        else if (!player.canPlayerEdit(x, y, z, side, item))
+        {
+            return false;
+        }
+        else
+        {
+            Block block = world.getBlock(x, y, z);
+            int i1 = world.getBlockMetadata(x, y, z);
+            int j1 = i1 & 3;
+            int k1 = i1 & 7;
+            boolean flag = (i1 & 8) != 0;
+
+            if ((side == 1 && !flag || side == 0 && flag) && block == getHalf() && j1 == item.getItemDamage())
+            {
+                if (world.checkNoEntityCollision(getDouble().getCollisionBoundingBoxFromPool(world, x, y, z)) && world.setBlock(x, y, z, getDouble(), k1, 3))
+                {
+                    world.playSoundEffect((double)((float)x + 0.5F), (double)((float)y + 0.5F), (double)((float)z + 0.5F), getDouble().stepSound.func_150496_b(), (getDouble().stepSound.getVolume() + 1.0F) / 2.0F, getDouble().stepSound.getPitch() * 0.8F);
+                    --item.stackSize;
+                }
+
+                return true;
+            }
+            else
+            {
+                return this.setSlab(item, player, world, x, y, z, side) ? true : super.onItemUse(item, player, world, x, y, z, side, fx, fy, fz);
+            }
+        }
+    }
+    
+    private boolean setSlab(ItemStack item, EntityPlayer player, World world, int x, int y, int z, int side)
+    {
+        if (side == 0)
+        {
+            --y;
+        }
+
+        if (side == 1)
+        {
+            ++y;
+        }
+
+        if (side == 2)
+        {
+            --z;
+        }
+
+        if (side == 3)
+        {
+            ++z;
+        }
+
+        if (side == 4)
+        {
+            --x;
+        }
+
+        if (side == 5)
+        {
+            ++x;
+        }
+
+        Block block = world.getBlock(x, y, z);
+        int i1 = world.getBlockMetadata(x, y, z);
+        int j1 = i1 & 7;
+
+        if (block == getHalf() && j1 == item.getItemDamage())
+        {
+            if (world.checkNoEntityCollision(getDouble().getCollisionBoundingBoxFromPool(world, x, y, z)) && world.setBlock(x, y, z, getDouble(), j1, 3))
+            {
+                world.playSoundEffect((double)((float)x + 0.5F), (double)((float)y + 0.5F), (double)((float)z + 0.5F), getDouble().stepSound.func_150496_b(), (getDouble().stepSound.getVolume() + 1.0F) / 2.0F, getDouble().stepSound.getPitch() * 0.8F);
+                --item.stackSize;
+            }
+
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    
+    protected abstract BlockSlabBase getHalf();
+    
+    protected abstract BlockSlabBase getDouble();
+
+}

--- a/ItemTatami.java
+++ b/ItemTatami.java
@@ -1,0 +1,23 @@
+package wa;
+
+import wa.block.BlockSlabBase;
+import wa.block.Blocks;
+import net.minecraft.block.Block;
+
+public class ItemTatami extends ItemSlabBase {
+
+	public ItemTatami(Block block) {
+		super(block);
+	}
+
+	@Override
+	protected BlockSlabBase getHalf() {
+		return Blocks.BlockWaHalfBlock;
+	}
+
+	@Override
+	protected BlockSlabBase getDouble() {
+		return Blocks.BlockWaDoubleBlock;
+	}
+
+}

--- a/ItemZabuton.java
+++ b/ItemZabuton.java
@@ -1,0 +1,98 @@
+package wa;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.World;
+
+/**
+ * @author defeatedcrow
+ */
+public class ItemZabuton extends ItemBlock {
+	
+	private final Block zabutonBlock;
+
+	public ItemZabuton(Block block)
+    {
+        super(block);
+        zabutonBlock = block;
+        this.setMaxDamage(0);
+        this.setHasSubtypes(true);
+    }
+    
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IIcon getIconFromDamage(int meta)
+    {
+        return Block.getBlockFromItem(this).getIcon(1, meta);
+    }
+
+    @Override
+    public int getMetadata(int meta)
+    {
+        return meta;
+    }
+    
+    @Override
+    public String getUnlocalizedName(ItemStack item)
+    {
+    	int m = item.getItemDamage() & 8;
+        return super.getUnlocalizedName() + "_" + m;
+    }
+    
+    @Override
+    public boolean onItemUse(ItemStack item, EntityPlayer player, World world, int x, int y, int z, int side, float fx, float fy, float fz)
+    {
+    	if (item == null || Block.getBlockFromItem(item.getItem()).isAir(world, x, y, z))
+        {
+            return false;
+        }
+    	else if (item.stackSize == 0)
+        {
+            return false;
+        }
+        else if (!player.canPlayerEdit(x, y, z, side, item))
+        {
+            return false;
+        }
+        else
+        {
+            Block block = world.getBlock(x, y, z);
+            int i1 = world.getBlockMetadata(x, y, z);
+            int j1 = i1 & 7;
+            int k1 = i1 & 8;
+            boolean flag = (i1 & 8) != 0;
+
+            if (block == zabutonBlock && k1 == item.getItemDamage())
+            {
+            	if (j1 < 7 )
+            	{
+            		if (world.setBlockMetadataWithNotify(x, y, z, i1 + 1, 3))
+                    {
+                        world.playSoundEffect((double)((float)x + 0.5F), (double)((float)y + 0.5F), (double)((float)z + 0.5F), field_150939_a.stepSound.func_150496_b(), (field_150939_a.stepSound.getVolume() + 1.0F) / 2.0F, field_150939_a.stepSound.getPitch() * 0.8F);
+                        --item.stackSize;
+                    }
+            	}
+            	else if (world.isAirBlock(x, y + 1, z))
+            	{
+            		if (world.setBlock(x, y + 1, z, block, k1, 3))
+                    {
+                        world.playSoundEffect((double)((float)x + 0.5F), (double)((float)y + 0.5F), (double)((float)z + 0.5F), field_150939_a.stepSound.func_150496_b(), (field_150939_a.stepSound.getVolume() + 1.0F) / 2.0F, field_150939_a.stepSound.getPitch() * 0.8F);
+                        --item.stackSize;
+                    }
+            	}
+
+                return true;
+            }
+            else
+            {
+                return super.onItemUse(item, player, world, x, y, z, side, fx, fy, fz);
+            }
+        }
+    }
+
+}

--- a/TileEntityKoto.java
+++ b/TileEntityKoto.java
@@ -1,0 +1,7 @@
+package wa;
+
+import net.minecraft.tileentity.TileEntity;
+
+public class TileEntityKoto extends TileEntity{
+
+}

--- a/TileEntityZabuton.java
+++ b/TileEntityZabuton.java
@@ -1,0 +1,11 @@
+package wa;
+
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * TESRを使うためだけのダミークラス
+ * @author defeatedcrow
+ * */
+public class TileEntityZabuton extends TileEntity {
+
+}

--- a/Wa.java
+++ b/Wa.java
@@ -28,7 +28,7 @@ public class Wa {
 	@Instance("Wa")
 	public static Wa instance;
 
-	@SidedProxy(clientSide = "wa.ClientProxy", serverSide = "wa.CommonProxy")
+	@SidedProxy(clientSide = "wa.client.ClientProxy", serverSide = "wa.CommonProxy")
 	public static CommonProxy proxy;
 
 	public static CreativeTabs creativeTab = new WaCreativeTabs();
@@ -53,6 +53,7 @@ public class Wa {
 		EntityRegistry.registerModEntity(EntityShuriken.class, "Shuriken", 1, this, 80, 1, true);
 		EntityRegistry.registerModEntity(EntityKakejiku.class, "Kakejiku", 2, this, 80, 1, true);
 		EntityRegistry.registerModEntity(EntityCoin.class, "Coin", 3, this, 80, 1, true);
+		EntityRegistry.registerModEntity(EntityZabuton.class, "Zabuton", 4, this, 80, 1, true);
 		//TODO レシピ追加
 		Recipes.init();
 		Items.init();

--- a/block/BlockIne.java
+++ b/block/BlockIne.java
@@ -41,4 +41,6 @@ public class BlockIne extends BlockCrops {
 			this.iconArray[i] = par1IconRegister.registerIcon("wa:ine_" + i);
 		}
 	}
+	
+	
 }

--- a/block/BlockKoto.java
+++ b/block/BlockKoto.java
@@ -1,13 +1,23 @@
 package wa.block;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import wa.TileEntityKoto;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class BlockKoto extends Block {
+public class BlockKoto extends BlockContainer {
 	private IIcon[] icons;
 
 	public BlockKoto(Material par2Material) {
@@ -21,7 +31,14 @@ public class BlockKoto extends Block {
 			float par8, float par9) {
 		if(par1World.isRemote) {
 			if(par5EntityPlayer.getCurrentEquippedItem() == null) {
-				par1World.playSound(par2, par3, par4, "wa.koto", 0.5F, 1.0F, false);
+				
+				/**
+				 * 音色を変えられるようにしてみた
+				 * @author defeatedcrow 
+				 */
+				float f = par7 * par9;
+				
+				par1World.playSound(par2, par3, par4, "wa:koto", 1.0F, f, false);
 			}
 		}
 		return super.onBlockActivated(par1World, par2, par3, par4, par5EntityPlayer,
@@ -30,14 +47,15 @@ public class BlockKoto extends Block {
 
 	@Override
 	public IIcon getIcon(int par1, int par2) {
-		return par1 == 1 ? icons[0] : icons[1];
+		return par1 == 1 ? (par2 == 4 ? icons[2] : icons[0]) : icons[1];
 	}
 
 	@Override
 	public void registerBlockIcons(IIconRegister par1IconRegister) {
-		icons = new IIcon[2];
+		icons = new IIcon[3];
 		icons[0] = par1IconRegister.registerIcon("wa:koto_head");
 		icons[1] = par1IconRegister.registerIcon("wa:koto_side");
+		icons[2] = par1IconRegister.registerIcon("wa:koto_head_1");
 	}
     public boolean isOpaqueCube()
     {
@@ -47,5 +65,65 @@ public class BlockKoto extends Block {
     {
         return false;
     }
+    
+    /**
+     * 向き変更用メソッド、レンダー用メソッドを追加
+     * @author defeatedcrow
+     */
+    
+    @Override
+	public void onBlockPlacedBy(World par1World, int par2, int par3, int par4, EntityLivingBase par5EntityLivingBase, ItemStack par6ItemStack)
+	{
+		int playerFacing = MathHelper.floor_double((double)((par5EntityLivingBase.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+		par1World.setBlockMetadataWithNotify(par2, par3, par4, playerFacing, 3);
+	}
+
+	@Override
+	public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
+		return new TileEntityKoto();
+	}
+	
+	public void setBlockBoundsForItemRender()
+    {
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.5F, 1.0F);
+    }
+	
+	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+        this.updateBounds(m);
+        return super.getCollisionBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getSelectedBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+        this.updateBounds(m);
+        return super.getSelectedBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	public void setBlockBoundsBasedOnState(IBlockAccess world, int par2, int par3, int par4)
+    {
+		float f = 0.5F - 0.125F;
+		float f1 = 0.5F + 0.125F;
+//		this.setBlockBounds(f, 0.125F, f, f1, 0.150F, f1);
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.5F, 1.0F);
+    }
+	
+	protected void updateBounds(int meta)
+    {
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.5F, 1.0F);
+    }
+	
+	@Override
+	public boolean shouldSideBeRendered(IBlockAccess par1IBlockAccess,
+			int par2, int par3, int par4, int par5) {
+		return false;
+	}
 
 }

--- a/block/BlockSlabBase.java
+++ b/block/BlockSlabBase.java
@@ -1,0 +1,190 @@
+package wa.block;
+
+import java.util.Random;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+/**
+ * バニラのhalfslabに向き変更機能を追加したもの
+ * @author defeatedcrow
+ * */
+public abstract class BlockSlabBase extends Block{
+	
+	protected final boolean isDouble;
+	
+	@SideOnly(Side.CLIENT)
+	protected IIcon[] topIcon;
+	@SideOnly(Side.CLIENT)
+	protected IIcon[] topIcon2;
+	@SideOnly(Side.CLIENT)
+	protected IIcon[] sideIcon;
+	
+	public BlockSlabBase (boolean b, Material material)
+	{
+		super(material);
+		this.setHardness(0.2F);
+		this.setResistance(2.0F);
+		this.setStepSound(Block.soundTypeCloth);
+		isDouble = b;
+	}
+	
+	//レンダーと当たり判定の処理
+	
+	@Override
+	public void setBlockBoundsForItemRender()
+    {
+        if (isDouble) {
+        	this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+        }
+        else
+        {
+        	float f = slabHeight();
+        	this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, f, 1.0F);
+        }
+    }
+	
+	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+        this.setBlockBoundsBasedOnState(par1World, par2, par3, par4);
+        return super.getCollisionBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getSelectedBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+        this.setBlockBoundsBasedOnState(par1World, par2, par3, par4);
+        return super.getSelectedBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	public void setBlockBoundsBasedOnState(IBlockAccess world, int par2, int par3, int par4)
+    {
+        this.updateBounds(world.getBlockMetadata(par2, par3, par4));
+    }
+	
+	protected void updateBounds(int par1)
+    {
+		if (isDouble) {
+        	this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+        }
+        else {
+        	float f = slabHeight();
+        	boolean rev = (par1 & 8) != 0;
+        	if (!rev) {
+        		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, f, 1.0F);
+        	}
+        	else {
+        		this.setBlockBounds(0.0F, 1.0F - f, 0.0F, 1.0F, 1.0F, 1.0F);
+        	}
+        }
+    }
+	
+	@Override
+	public boolean isOpaqueCube()
+    {
+        return false;
+    }
+	
+	@Override
+	public boolean renderAsNormalBlock()
+    {
+        return false;
+    }
+	
+	//アイコン
+	
+	@SideOnly(Side.CLIENT)
+	public IIcon getIcon (int par1, int par2)
+	{
+		int meta = par2 & 3;
+		int i = Math.min(meta, topIconString().length - 1);
+		int j = Math.min(meta, topIconString2().length - 1);
+		int k = Math.min(meta, sideIconString().length - 1);
+		if (par1 == 0 || par1 == 1) {
+			return (par2 & 4) != 0 ? topIcon2[j] : topIcon[i];
+		}
+		else
+		{
+			return sideIcon[k];
+		}
+	}
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void registerBlockIcons(IIconRegister par1IconRegister)
+	{
+		for (int i = 0 ; i < topIconString().length ; i++)
+		{
+			topIcon = new IIcon[topIconString().length];
+			topIcon[i] = par1IconRegister.registerIcon("wa:" + topIconString()[i]);
+		}
+		
+		for (int j = 0 ; j < topIconString2().length ; j++)
+		{
+			topIcon2 = new IIcon[topIconString2().length];
+			topIcon2[j] = par1IconRegister.registerIcon("wa:" + topIconString2()[j]);
+		}
+		
+		for (int k = 0 ; k < sideIconString().length ; k++)
+		{
+			sideIcon = new IIcon[sideIconString().length];
+			sideIcon[k] = par1IconRegister.registerIcon("wa:" + sideIconString()[k]);
+		}
+	}
+	
+	protected abstract String[] topIconString();
+	
+	protected abstract String[] topIconString2();
+	
+	protected abstract String[] sideIconString();
+	
+	protected abstract float slabHeight();
+	
+	//半ブロックの動作
+	@Override
+	public int onBlockPlaced(World world, int x, int y, int z, int side, float fx, float fy, float fz, int meta)
+    {
+        return this.isDouble ? meta : (side != 0 && (side == 1 || (double)fy <= 0.5D) ? meta : meta | 8);
+    }
+	
+	//設置時の向き
+	@Override
+	public void onBlockPlacedBy(World par1World, int par2, int par3, int par4, EntityLivingBase par5EntityLivingBase, ItemStack par6ItemStack)
+	{
+		int playerFacing = MathHelper.floor_double((double)((par5EntityLivingBase.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+		
+		if (playerFacing == 0 || playerFacing == 2) {
+			par1World.setBlockMetadataWithNotify(par2, par3, par4, m | 4, 3);
+		}
+		else {
+			par1World.setBlockMetadataWithNotify(par2, par3, par4, m, 3);
+		}
+	}
+
+	@Override
+    public int quantityDropped(Random rand)
+    {
+        return this.isDouble ? 2 : 1;
+    }
+
+	@Override
+    public int damageDropped(int meta)
+    {
+        return meta & 3;
+    }
+
+}

--- a/block/BlockSusuki.java
+++ b/block/BlockSusuki.java
@@ -2,13 +2,23 @@ package wa.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import java.util.Random;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
 public class BlockSusuki extends Block {
+	
+	public static int renderID;
+	@SideOnly(Side.CLIENT)
+	private IIcon[] iconType;
 
 	public BlockSusuki(Material par2Material) {
 		super(par2Material);
@@ -19,7 +29,7 @@ public class BlockSusuki extends Block {
 	@Override
 	public boolean canPlaceBlockAt(World par1World, int par2, int par3, int par4) {
 		Block block = par1World.getBlock(par2, par3 - 1, par4);
-		if(block == this || block == Blocks.dirt || block == Blocks.grass) {
+		if(block == this || block == Blocks.dirt || block.getMaterial() == Material.grass) {
 			return true;
 		}
 		return false;
@@ -62,11 +72,42 @@ public class BlockSusuki extends Block {
 
 	@Override
 	public int getRenderType() {
-		return 1;
+		return renderID;
 	}
 
 	@Override
 	public Item getItem(World par1World, int par2, int par3, int par4) {
 		return Item.getItemFromBlock(Blocks.susuki);
+	}
+	
+	
+	/**
+	 * 機能追加部分
+	 * @author defeatedcrow
+	 */
+	
+	@Override
+	public IIcon getIcon(int par1, int par2) {
+		if (par1 < 0 || par1 > 5) {
+			par1 = 5;
+		}
+		return this.iconType[par1];
+	}
+	
+	@SideOnly(Side.CLIENT)
+    public IIcon getIcon(IBlockAccess world, int x, int y, int z, int side) {
+		boolean connectTop = world.getBlock(x, y + 1, z) == this;
+		boolean connectBottom = world.getBlock(x, y - 1, z) == this;
+		
+        return connectTop ? (connectBottom ? iconType[2] : iconType[1]) : iconType[0];
+    }
+	
+	@Override
+	public void registerBlockIcons(IIconRegister par1IconRegister) {
+		this.iconType = new IIcon[6];
+
+		for (int i = 0; i < this.iconType.length; ++i) {
+			this.iconType[i] = par1IconRegister.registerIcon("wa:susuki_" + i);
+		}
 	}
 }

--- a/block/BlockTaiko.java
+++ b/block/BlockTaiko.java
@@ -23,7 +23,7 @@ public class BlockTaiko extends Block {
 		if (par1World.isRemote) {
 			ItemStack itemStack = par5EntityPlayer.getCurrentEquippedItem();
 			if (itemStack != null && itemStack.getItem() == Items.stick) {
-				par1World.playSound(par2, par3, par4, "wa.taiko", 0.5F, 1.0F,
+				par1World.playSound(par2, par3, par4, "wa:taiko", 0.5F, 1.0F,
 						false);
 			}
 		}
@@ -43,8 +43,8 @@ public class BlockTaiko extends Block {
 	@Override
 	public void registerBlockIcons(IIconRegister par1IconRegister) {
 		icons = new IIcon[2];
-		icons[0] = par1IconRegister.registerIcon("wa:taiko_head");
-		icons[1] = par1IconRegister.registerIcon("wa:taiko_side");
+		icons[0] = par1IconRegister.registerIcon("wa:taiko_head_alt");
+		icons[1] = par1IconRegister.registerIcon("wa:taiko_side_alt");
 	}
 
 	public int onBlockPlaced(World par1World, int par2, int par3, int par4,

--- a/block/BlockTatami.java
+++ b/block/BlockTatami.java
@@ -4,18 +4,22 @@ import net.minecraft.block.BlockSlab;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 import java.util.List;
 import java.util.Random;
 
-public class BlockTatami extends BlockSlab {
-
-	IIcon[] icons;
+/**
+ * BlockSlubの動作が怪しいため継承先を変更
+ * 
+ */
+public class BlockTatami extends BlockSlabBase {
 
 	public BlockTatami(boolean par2, Material par3Material) {
 		super(par2, par3Material);
@@ -23,24 +27,13 @@ public class BlockTatami extends BlockSlab {
 	}
 
 	@Override
-	public IIcon getIcon(int par1, int par2) {
-		return icons[0];
-	}
-
-	@Override
-	public void registerBlockIcons(IIconRegister par1IconRegister) {
-		icons = new IIcon[1];
-		icons[0] = par1IconRegister.registerIcon("wa:tatami");
-	}
-
-	@Override
 	public Item getItemDropped(int par1, Random par2Random, int par3) {
-		return Item.getItemFromBlock(this);
+		return Item.getItemFromBlock(Blocks.BlockWaHalfBlock);
 	}
 
 	@Override
 	protected ItemStack createStackedBlock(int par1) {
-		return new ItemStack(this, 2, par1 & 7);
+		return new ItemStack(this, 2, par1 & 3);
 	}
 
 	@Override
@@ -52,18 +45,52 @@ public class BlockTatami extends BlockSlab {
 	@Override
 	public boolean shouldSideBeRendered(IBlockAccess par1IBlockAccess,
 			int par2, int par3, int par4, int par5) {
-		return true;
+		return super.shouldSideBeRendered(par1IBlockAccess, par2, par3, par4, par5);
 	}
 
-    @Override
-	public String func_150002_b(int i) {
-		return super.getUnlocalizedName() + "." + "tatami";
+//    @Override
+//	public String func_150002_b(int i) {
+//		return super.getUnlocalizedName() + "." + "tatami";
+//	}
+
+//	@Override
+//	public Item getItem(World par1World, int par2, int par3, int par4) {
+//		//return Blocks.畳.blockID;
+//		return null;
+//	}
+	
+	/* 追加メソッド */
+	
+	@Override
+	public boolean isOpaqueCube()
+	{
+		return false;
+	}
+ 
+	@Override
+	public boolean renderAsNormalBlock() 
+	{
+		return false;
 	}
 
 	@Override
-	public Item getItem(World par1World, int par2, int par3, int par4) {
-		//return Blocks.畳.blockID;
-		return null;
+	protected String[] topIconString() {
+		return new String[] {"tatami"};
+	}
+	
+	@Override
+	protected String[] topIconString2() {
+		return new String[] {"tatami_v"};
+	}
+
+	@Override
+	protected String[] sideIconString() {
+		return new String[] {"tatami"};
+	}
+
+	@Override
+	protected float slabHeight() {
+		return 0.5F;
 	}
 
 }

--- a/block/BlockUmeWood.java
+++ b/block/BlockUmeWood.java
@@ -6,13 +6,16 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.BlockLog;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import wa.EntityUmeLeavesFX;
 import wa.Items;
-import wa.Particles;
+import wa.client.Particles;
 
 import java.util.List;
 import java.util.Random;
@@ -33,7 +36,7 @@ public class BlockUmeWood extends BlockLog {
 
 	@Override
 	public int damageDropped(int par1) {
-		return par1;
+		return 0;
 	}
 
 	@Override
@@ -89,14 +92,17 @@ public class BlockUmeWood extends BlockLog {
 
 	@Override
 	public IIcon getIcon(int par1, int par2) {
-		return icons[1];
+		int i = MathHelper.clamp_int(par1, 0, 2);
+		return icons[i];
 	}
 
+	//変更点:アイコンを変えた
 	@Override
 	public void registerBlockIcons(IIconRegister par1IconRegister) {
-		icons = new IIcon[2];
+		icons = new IIcon[3];
 		icons[0] = par1IconRegister.registerIcon("log_oak_top");
 		icons[1] = par1IconRegister.registerIcon("log_oak");
+		icons[2] = par1IconRegister.registerIcon("Wa:umeLeaves");
 	}
 
 	@Override
@@ -133,6 +139,36 @@ public class BlockUmeWood extends BlockLog {
 				entityFX.setParticleIcon(Particles.getInstance().getIcon("wa:ume"));
 				FMLClientHandler.instance().getClient().effectRenderer.addEffect(entityFX);
 			}
+	}
+	
+	/* 追加点 */
+	
+	@Override
+	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase living, ItemStack item)
+	{
+		int playerFacing = MathHelper.floor_double((double)((living.rotationYaw * 4F) / 360F) + 0.5D) & 3;
+ 
+		boolean tall = false;
+		
+		if (living != null && living instanceof EntityPlayer)
+		{
+			tall = living.isSneaking();
+		}
+		else
+		{
+			tall = false;
+		}
+		
+		//スニークしながら設置した場合、メタデータが1になる。
+		//メタ1は強制的に花レンダーになる。
+		if (tall)
+		{
+			world.setBlockMetadataWithNotify(x, y, z, 1, 3);
+		}
+		else
+		{
+			world.setBlockMetadataWithNotify(x, y, z, 0, 3);
+		}
 	}
 
 }

--- a/block/BlockZabuton.java
+++ b/block/BlockZabuton.java
@@ -1,33 +1,48 @@
 package wa.block;
 
+import mods.defeatedcrow.common.DCsAppleMilk;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockSlab;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-public class BlockZabuton extends BlockSlab {
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import wa.*;
+
+/**
+ * 内容を色々と変更しました
+ * 使用メタは0-7と8-15、一応2色用意
+ * 一段目のみBlockのレンダーを使い、二段目以降にモデルを使用
+ * 
+ * @author defeatedcrow
+ * */
+public class BlockZabuton extends BlockContainer {
 
 	IIcon[] icons;
 
-	public BlockZabuton(boolean par2, Material par3Material) {
-		super(par2, par3Material);
+	public BlockZabuton(Material par3Material) {
+		super(par3Material);
 		// TODO 自動生成されたコンストラクター・スタブ
 	}
 
 	@Override
-	public String func_150002_b(int i) {
-		return super.getUnlocalizedName() + "." + "zabuton";
-	}
-
-	@Override
 	public IIcon getIcon(int par1, int par2) {
-		return icons[0];
+		return isAltColor(par2) ? icons[1] : icons[0];
 	}
 
 	@Override
@@ -35,19 +50,133 @@ public class BlockZabuton extends BlockSlab {
 		return Item.getItemFromBlock(this);
 	}
 
-	@Override
-	protected ItemStack createStackedBlock(int par1) {
-		return new ItemStack(this, 2, par1 & 7);
-	}
+//	@Override
+//	protected ItemStack createStackedBlock(int par1) {
+//		return new ItemStack(this, 2, par1 & 8);
+//	}
 
 	@Override
 	public void getSubBlocks(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
 		par3List.add(new ItemStack(par1, 1, 0));
+		par3List.add(new ItemStack(par1, 1, 8));
 	}
 
 	@Override
 	public void registerBlockIcons(IIconRegister par1IconRegister) {
-		icons = new IIcon[1];
+		icons = new IIcon[2];
 		icons[0] = par1IconRegister.registerIcon("wa:zabuton");
+		icons[1] = par1IconRegister.registerIcon("wa:zabuton_alt");
 	}
+	
+	private boolean isAltColor(int meta)
+	{
+		return (meta & 8) != 0;
+	}
+
+	@Override
+	public TileEntity createNewTileEntity(World world, int meta) {
+		return new TileEntityZabuton();
+	}
+	
+	/* 以下、追加メソッド */
+	
+	// レンダーと当たり判定
+	
+	@Override
+	public void setBlockBoundsForItemRender()
+    {
+		float f = 0.125F;
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, f, 1.0F);
+    }
+	
+	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+        this.updateBounds(m);
+        return super.getCollisionBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getSelectedBoundingBoxFromPool(World par1World, int par2, int par3, int par4)
+    {
+		int m = par1World.getBlockMetadata(par2, par3, par4);
+        this.updateBounds(m);
+        return super.getSelectedBoundingBoxFromPool(par1World, par2, par3, par4);
+    }
+	
+	@Override
+	public void setBlockBoundsBasedOnState(IBlockAccess world, int par2, int par3, int par4)
+    {
+		float f = 0.125F;
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, f, 1.0F);
+    }
+	
+	protected void updateBounds(int meta)
+    {
+		int m = meta & 7;
+		float f = 0.125F * m;
+		this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 0.125F + f, 1.0F);
+    }
+	
+	@Override
+	public boolean isOpaqueCube()
+    {
+        return false;
+    }
+	
+	@Override
+	public boolean renderAsNormalBlock()
+    {
+        return false;
+    }
+	
+	@Override
+    public int quantityDropped(Random rand)
+    {
+        return 0;
+    }
+
+	@Override
+    public int damageDropped(int meta)
+    {
+        return meta & 8;
+    }
+	
+	// Entityの生成
+	
+	@Override
+	public void onBlockAdded(World world, int x, int y, int z)
+	{
+		super.onBlockAdded(world, x, y, z);
+		if (!world.isRemote)
+		{
+			EntityZabuton entity = new EntityZabuton(world, x + 0.5D, y, z + 0.5D);
+			world.spawnEntityInWorld(entity);
+		}
+		
+	}
+	
+	// 破壊時の動作
+	
+	@Override
+	public void breakBlock(World world, int x, int y, int z, Block par5, int par6)
+    {
+		if (!world.isRemote)
+        {
+			int m = par6;
+			int color = m & 8;
+			int size = m & 7;
+			
+			float f = 0.7F;
+            double d0 = (double)(world.rand.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+            double d1 = (double)(world.rand.nextFloat() * f) + (double)(1.0F - f) * 0.2D + 0.6D;
+            double d2 = (double)(world.rand.nextFloat() * f) + (double)(1.0F - f) * 0.5D;
+            ItemStack drop = new ItemStack(this, size + 1, color);
+            EntityItem entityitem = new EntityItem(world, (double)x + d0, (double)y + d1, (double)z + d2, drop);
+            entityitem.delayBeforeCanPickup = 10;
+            world.spawnEntityInWorld(entityitem);
+        }
+    }
 }

--- a/block/Blocks.java
+++ b/block/Blocks.java
@@ -25,8 +25,8 @@ public class Blocks extends net.minecraft.init.Blocks {
 	public static Block tataraBlock = (new BlockTatara(Material.rock)).setHardness(3.0F).setResistance(5.0F).setStepSound(Block.soundTypeStone).setBlockName("wa:tatara").setCreativeTab(Wa.creativeTab);
 	public static Block portal = new BlockWaPortal(Material.portal).setHardness(-1.0F).setResistance(6000000.0F).setBlockName("wa:portal").setCreativeTab(Wa.creativeTab);
 	public static Block wara = new WaBlock(Material.grass).setHardness(0.2F).setStepSound(Block.soundTypeGrass).setBlockName("wa:wara").setBlockTextureName("wa:wara").setCreativeTab(Wa.creativeTab);
-	public static BlockSlab BlockWaHalfBlock = (BlockSlab)(new BlockWaStep(false)).setHardness(1.0F).setStepSound(Block.soundTypeCloth).setBlockName("wa:step");
-	public static BlockSlab BlockWaDoubleBlock = (BlockSlab)(new BlockWaStep(true)).setHardness(1.0F).setStepSound(Block.soundTypeCloth).setBlockName("wa:step");
+	public static BlockSlabBase BlockWaHalfBlock = (BlockSlabBase)(new BlockTatami(false, Material.cloth)).setHardness(0.2F).setStepSound(Block.soundTypeCloth).setBlockName("wa:step").setCreativeTab(Wa.creativeTab);
+	public static BlockSlabBase BlockWaDoubleBlock = (BlockSlabBase)(new BlockTatami(true, Material.cloth)).setHardness(0.2F).setStepSound(Block.soundTypeCloth).setBlockName("wa:step");
 	static public Block shikui = new BlockShikui(Material.clay).setHardness(0.6F).setStepSound(Block.soundTypeGravel).setBlockName("wa:shikui").setCreativeTab(Wa.creativeTab);
 	static public Block sakuraWood = (new BlockSakuraWood()).setHardness(2.0F).setStepSound(Block.soundTypeWood).setBlockName("wa:sakuraWood").setCreativeTab(Wa.creativeTab);
 	static public BlockLeaves sakuraLeaves = (BlockLeaves)(new BlockSakuraLeaves()).setHardness(0.2F).setLightOpacity(1).setStepSound(Block.soundTypeGrass).setBlockName("wa:sakuraLeaves").setCreativeTab(Wa.creativeTab);
@@ -61,7 +61,9 @@ public class Blocks extends net.minecraft.init.Blocks {
     // または磁石を砂or砂利に使うと砂鉄が得られる
     // メタデータが変更されて2回は取れない
     // 砂鉄はironDust的存在、9個でインゴットに
-
+    
+    /* defeatedcrow作成物 */
+    public static Block zabuton = (new BlockZabuton(Material.sponge)).setHardness(0.2F).setStepSound(Block.soundTypeCloth).setBlockName("wa:zabuton").setBlockTextureName("wa:zabuton").setCreativeTab(Wa.creativeTab);
 
 
 	//TODO 入手方法を実装
@@ -79,10 +81,12 @@ public class Blocks extends net.minecraft.init.Blocks {
 	static Block 障子;
 
 	public static void preInit() {
-		//ItemBlock itemBlockSingle = (ItemBlock) new ItemWaSlab(BlockWaHalfBlock, BlockWaHalfBlock, BlockWaDoubleBlock, false).setUnlocalizedName("wa:step");
-		//ItemBlock itemBlockDouble = (ItemBlock) new ItemWaSlab(BlockWaDoubleBlock, BlockWaHalfBlock, BlockWaDoubleBlock, true).setUnlocalizedName("wa:step");
-		GameRegistry.registerBlock(BlockWaHalfBlock, ItemWaSlab.class, "WaHalfBlock", BlockWaHalfBlock, BlockWaDoubleBlock, false);
-		GameRegistry.registerBlock(BlockWaDoubleBlock, ItemWaSlab.class, "WaDoubleBlock", BlockWaHalfBlock, BlockWaDoubleBlock, true);
+//		ItemBlock itemBlockSingle = (ItemBlock) new ItemSlabBase(BlockWaHalfBlock, BlockWaHalfBlock, BlockWaDoubleBlock, false).setUnlocalizedName("wa:step");
+//		ItemBlock itemBlockDouble = (ItemBlock) new ItemSlabBase(BlockWaDoubleBlock, BlockWaHalfBlock, BlockWaDoubleBlock, true).setUnlocalizedName("wa:step");
+//		GameRegistry.registerBlock(BlockWaHalfBlock, ItemWaSlab.class, "WaHalfBlock", BlockWaHalfBlock, BlockWaDoubleBlock, false);
+//		GameRegistry.registerBlock(BlockWaDoubleBlock, ItemWaSlab.class, "WaDoubleBlock", BlockWaHalfBlock, BlockWaDoubleBlock, true);
+		GameRegistry.registerBlock(BlockWaHalfBlock, ItemTatami.class, "WaHalfBlock");
+		GameRegistry.registerBlock(BlockWaDoubleBlock, ItemTatami.class, "WaDoubleBlock");
 
 		LanguageRegistry.instance().addStringLocalization("tile.wa:step.tatami.name", "en_US", "tatami");
 		LanguageRegistry.instance().addStringLocalization("tile.wa:step.tatami.name", "ja_JP", "畳");
@@ -143,6 +147,9 @@ public class Blocks extends net.minecraft.init.Blocks {
             //GameRegistry.registerBlock(colorWood[i], "paintedWood(" + ItemDye.field_150923_a[i] + ")", "色付き木材(" + ItemDye.field_150923_a[i] + ")");
             GameRegistry.registerBlock(colorWood[i], "paintedWood(" + ItemDye.field_150923_a[i] + ")");
 		}
+		
+		/* defeatedcrow作成物 */
+		GameRegistry.registerBlock(zabuton, ItemZabuton.class, "zabuton");
 
 		//ケラは金槌が対応ツールになる
 		//MinecraftForge.removeBlockEffectiveness(kera, 0, "pickaxe");

--- a/client/ClientProxy.java
+++ b/client/ClientProxy.java
@@ -1,16 +1,16 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.registry.VillagerRegistry;
 import net.minecraft.stats.Achievement;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-import wa.block.BlockCharm;
-import wa.block.BlockKawara;
-import wa.block.BlockNoren;
-import wa.block.BlockUmeWood;
+import wa.*;
+import wa.block.*;
+import wa.client.*;
 
 import java.io.*;
 
@@ -31,11 +31,20 @@ public class ClientProxy extends CommonProxy {
 		RenderingRegistry.registerEntityRenderingHandler(EntityCoin.class, new RenderCoin());
 
 		BlockUmeWood.renderID = RenderingRegistry.getNextAvailableRenderId();
-		RenderingRegistry.registerBlockHandler(new RenderUmeWood());
+		RenderingRegistry.registerBlockHandler(new RenderUmeLog());
 
 		BlockKawara.renderID = RenderingRegistry.getNextAvailableRenderId();
 		RenderingRegistry.registerBlockHandler(new RenderKawaraBlock());
+		
+		BlockSusuki.renderID = RenderingRegistry.getNextAvailableRenderId();
+		RenderingRegistry.registerBlockHandler(new RenderSusuki());
 
+		// defeatedcrow追加物
+		RenderingRegistry.registerEntityRenderingHandler(EntityZabuton.class, new RenderZabutonEntity());
+		
+		ClientRegistry.registerTileEntity(TileEntityZabuton.class, "tileentityZabuton", new RenderZabutonBlock());
+		ClientRegistry.registerTileEntity(TileEntityKoto.class, "tileentityKoto", new RenderKotoBlock());
+		
 		MinecraftForge.EVENT_BUS.register(new Particles());
 
 		VillagerRegistry.instance().registerVillagerSkin(Config.町人ID, new ResourceLocation("wa", "textures/villager.png"));

--- a/client/ModelKoto.java
+++ b/client/ModelKoto.java
@@ -1,0 +1,140 @@
+package wa.client;
+
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.entity.Entity;
+
+public class ModelKoto extends ModelBase
+{
+	  //fields
+	    ModelRenderer base1;
+	    ModelRenderer base2;
+	    ModelRenderer base3;
+	    ModelRenderer kaku1;
+	    ModelRenderer kaku2;
+	    ModelRenderer ashi1;
+	    ModelRenderer ashi2;
+	    ModelRenderer ji1;
+	    ModelRenderer ji2;
+	    ModelRenderer ji3;
+	    ModelRenderer ji4;
+	    ModelRenderer ji5;
+	    ModelRenderer ji6;
+	  
+	  public ModelKoto()
+	  {
+	    textureWidth = 64;
+	    textureHeight = 64;
+	    
+	      base1 = new ModelRenderer(this, 0, 0);
+	      base1.addBox(-10F, 4F, -4F, 20, 3, 8);
+	      base1.setRotationPoint(0F, 16F, 0F);
+	      base1.setTextureSize(64, 64);
+	      base1.mirror = true;
+	      setRotation(base1, 0F, 0F, 0.0523599F);
+	      base2 = new ModelRenderer(this, 0, 14);
+	      base2.addBox(-14F, 3.5F, -4F, 4, 3, 8);
+	      base2.setRotationPoint(0F, 16F, 0F);
+	      base2.setTextureSize(64, 64);
+	      base2.mirror = true;
+	      setRotation(base2, 0F, 0F, 0F);
+	      base3 = new ModelRenderer(this, 29, 14);
+	      base3.addBox(10F, 4F, -4F, 7, 3, 8);
+	      base3.setRotationPoint(0F, 16F, 0F);
+	      base3.setTextureSize(64, 64);
+	      base3.mirror = true;
+	      setRotation(base3, 0F, 0F, 0.0523599F);
+	      kaku1 = new ModelRenderer(this, 0, 28);
+	      kaku1.addBox(-11F, 2.5F, -4F, 1, 1, 8);
+	      kaku1.setRotationPoint(0F, 16F, 0F);
+	      kaku1.setTextureSize(64, 64);
+	      kaku1.mirror = true;
+	      setRotation(kaku1, 0F, 0F, 0F);
+	      kaku2 = new ModelRenderer(this, 0, 28);
+	      kaku2.addBox(10F, 3.5F, -4F, 1, 1, 8);
+	      kaku2.setRotationPoint(0F, 16F, 0F);
+	      kaku2.setTextureSize(64, 64);
+	      kaku2.mirror = true;
+	      setRotation(kaku2, 0F, 0F, 0F);
+	      ashi1 = new ModelRenderer(this, 24, 28);
+	      ashi1.addBox(-13F, 6F, -3F, 2, 2, 2);
+	      ashi1.setRotationPoint(0F, 16F, 0F);
+	      ashi1.setTextureSize(64, 64);
+	      ashi1.mirror = true;
+	      setRotation(ashi1, 0F, 0F, 0F);
+	      ashi2 = new ModelRenderer(this, 24, 28);
+	      ashi2.addBox(-13F, 6F, 1F, 2, 2, 2);
+	      ashi2.setRotationPoint(0F, 16F, 0F);
+	      ashi2.setTextureSize(64, 64);
+	      ashi2.mirror = true;
+	      setRotation(ashi2, 0F, 0F, 0F);
+	      ji1 = new ModelRenderer(this, 33, 28);
+	      ji1.addBox(-8F, 3F, 2F, 1, 1, 1);
+	      ji1.setRotationPoint(0F, 16F, 0F);
+	      ji1.setTextureSize(64, 64);
+	      ji1.mirror = true;
+	      setRotation(ji1, 0F, 0F, 0F);
+	      ji2 = new ModelRenderer(this, 33, 28);
+	      ji2.addBox(-5F, 3F, 1F, 1, 1, 1);
+	      ji2.setRotationPoint(0F, 16F, 0F);
+	      ji2.setTextureSize(64, 64);
+	      ji2.mirror = true;
+	      setRotation(ji2, 0F, 0F, 0F);
+	      ji3 = new ModelRenderer(this, 33, 28);
+	      ji3.addBox(-3F, 3F, 0F, 1, 1, 1);
+	      ji3.setRotationPoint(0F, 16F, 0F);
+	      ji3.setTextureSize(64, 64);
+	      ji3.mirror = true;
+	      setRotation(ji3, 0F, 0F, 0F);
+	      ji4 = new ModelRenderer(this, 33, 28);
+	      ji4.addBox(0F, 3F, -1F, 1, 1, 1);
+	      ji4.setRotationPoint(0F, 16F, 0F);
+	      ji4.setTextureSize(64, 64);
+	      ji4.mirror = true;
+	      setRotation(ji4, 0F, 0F, 0F);
+	      ji5 = new ModelRenderer(this, 33, 28);
+	      ji5.addBox(2F, 3F, -2F, 1, 1, 1);
+	      ji5.setRotationPoint(0F, 16F, 0F);
+	      ji5.setTextureSize(64, 64);
+	      ji5.mirror = true;
+	      setRotation(ji5, 0F, 0F, 0F);
+	      ji6 = new ModelRenderer(this, 33, 28);
+	      ji6.addBox(5F, 3F, -3F, 1, 1, 1);
+	      ji6.setRotationPoint(0F, 16F, 0F);
+	      ji6.setTextureSize(64, 64);
+	      ji6.mirror = true;
+	      setRotation(ji6, 0F, 0F, 0F);
+	  }
+	  
+	  public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5)
+	  {
+	    super.render(entity, f, f1, f2, f3, f4, f5);
+	    setRotationAngles(f, f1, f2, f3, f4, f5);
+	    base1.render(f5);
+	    base2.render(f5);
+	    base3.render(f5);
+	    kaku1.render(f5);
+	    kaku2.render(f5);
+	    ashi1.render(f5);
+	    ashi2.render(f5);
+	    ji1.render(f5);
+	    ji2.render(f5);
+	    ji3.render(f5);
+	    ji4.render(f5);
+	    ji5.render(f5);
+	    ji6.render(f5);
+	  }
+	  
+	  private void setRotation(ModelRenderer model, float x, float y, float z)
+	  {
+	    model.rotateAngleX = x;
+	    model.rotateAngleY = y;
+	    model.rotateAngleZ = z;
+	  }
+	  
+	  public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5)
+	  {
+	    super.setRotationAngles(f, f1, f2, f3, f4, f5, null);
+	  }
+
+	}

--- a/client/ModelZabuton.java
+++ b/client/ModelZabuton.java
@@ -1,0 +1,111 @@
+package wa.client;
+
+import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.model.ModelRenderer;
+import net.minecraft.entity.Entity;
+
+public class ModelZabuton extends ModelBase
+{
+  //fields
+    ModelRenderer zabuton1;
+    ModelRenderer zabuton2;
+    ModelRenderer zabuton3;
+    ModelRenderer zabuton4;
+    ModelRenderer zabuton5;
+    ModelRenderer zabuton6;
+    ModelRenderer zabuton7;
+    ModelRenderer zabuton8;
+  
+  public ModelZabuton()
+  {
+    textureWidth = 64;
+    textureHeight = 32;
+    
+      zabuton1 = new ModelRenderer(this, 0, 0);
+      zabuton1.addBox(-8F, 6F, -8F, 16, 2, 16);
+      zabuton1.setRotationPoint(0F, 16F, 0F);
+      zabuton1.setTextureSize(64, 32);
+      zabuton1.mirror = true;
+      setRotation(zabuton1, 0F, 0F, 0F);
+      zabuton2 = new ModelRenderer(this, 0, 0);
+      zabuton2.addBox(-8F, 4F, -8F, 16, 2, 16);
+      zabuton2.setRotationPoint(0F, 16F, 0F);
+      zabuton2.setTextureSize(64, 32);
+      zabuton2.mirror = true;
+      setRotation(zabuton2, 0F, 0.1396263F, 0F);
+      zabuton3 = new ModelRenderer(this, 0, 0);
+      zabuton3.addBox(-8F, 2F, -8F, 16, 2, 16);
+      zabuton3.setRotationPoint(0F, 16F, 0F);
+      zabuton3.setTextureSize(64, 32);
+      zabuton3.mirror = true;
+      setRotation(zabuton3, 0F, -0.0349066F, 0F);
+      zabuton4 = new ModelRenderer(this, 0, 0);
+      zabuton4.addBox(-8F, 0F, -9F, 16, 2, 16);
+      zabuton4.setRotationPoint(0F, 16F, 0F);
+      zabuton4.setTextureSize(64, 32);
+      zabuton4.mirror = true;
+      setRotation(zabuton4, 0.0349066F, -0.0698132F, 0F);
+      zabuton5 = new ModelRenderer(this, 0, 0);
+      zabuton5.addBox(-8F, -2F, -8F, 16, 2, 16);
+      zabuton5.setRotationPoint(0F, 16F, 0F);
+      zabuton5.setTextureSize(64, 32);
+      zabuton5.mirror = true;
+      setRotation(zabuton5, 0F, 0F, 0F);
+      zabuton6 = new ModelRenderer(this, 0, 0);
+      zabuton6.addBox(-8F, -4F, -8F, 16, 2, 16);
+      zabuton6.setRotationPoint(0F, 16F, 0F);
+      zabuton6.setTextureSize(64, 32);
+      zabuton6.mirror = true;
+      setRotation(zabuton6, -0.0174533F, 0.0523599F, 0F);
+      zabuton7 = new ModelRenderer(this, 0, 0);
+      zabuton7.addBox(-8F, -6F, -8F, 16, 2, 16);
+      zabuton7.setRotationPoint(0F, 16F, 0F);
+      zabuton7.setTextureSize(64, 32);
+      zabuton7.mirror = true;
+      setRotation(zabuton7, 0F, -0.1745329F, 0F);
+      zabuton8 = new ModelRenderer(this, 0, 0);
+      zabuton8.addBox(-8F, -8F, -8F, 16, 2, 16);
+      zabuton8.setRotationPoint(0F, 16F, 0F);
+      zabuton8.setTextureSize(64, 32);
+      zabuton8.mirror = true;
+      setRotation(zabuton8, 0F, 0.0349066F, 0F);
+  }
+  
+  public void render(Entity entity, float f, float f1, float f2, float f3, float f4, float f5, int meta)
+  {
+    super.render(entity, f, f1, f2, f3, f4, f5);
+    setRotationAngles(f, f1, f2, f3, f4, f5);
+    switch (meta)
+    {
+    case 7:
+    	zabuton8.render(f5);
+    case 6:
+    	zabuton7.render(f5);
+    case 5:
+    	zabuton6.render(f5);
+    case 4:
+    	zabuton5.render(f5);
+    case 3:
+    	zabuton4.render(f5);
+    case 2:
+    	zabuton3.render(f5);
+    case 1:
+    	zabuton2.render(f5);
+    	default:
+    		break;
+    }
+  }
+  
+  private void setRotation(ModelRenderer model, float x, float y, float z)
+  {
+    model.rotateAngleX = x;
+    model.rotateAngleY = y;
+    model.rotateAngleZ = z;
+  }
+  
+  public void setRotationAngles(float f, float f1, float f2, float f3, float f4, float f5)
+  {
+    super.setRotationAngles(f, f1, f2, f3, f4, f5, null);
+  }
+
+}

--- a/client/Particles.java
+++ b/client/Particles.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;

--- a/client/RenderCharmBlock.java
+++ b/client/RenderCharmBlock.java
@@ -1,13 +1,13 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
-import wa.block.BlockNoren;
+import wa.block.BlockCharm;
 
-public class RenderNorenBlock implements ISimpleBlockRenderingHandler {
+public class RenderCharmBlock implements ISimpleBlockRenderingHandler {
 
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelID,
@@ -42,7 +42,7 @@ public class RenderNorenBlock implements ISimpleBlockRenderingHandler {
 
 	@Override
 	public int getRenderId() {
-		return BlockNoren.renderID;
+		return BlockCharm.renderID;
 	}
 
 }

--- a/client/RenderCoin.java
+++ b/client/RenderCoin.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import net.minecraft.client.Minecraft;
@@ -6,8 +6,11 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+
+import wa.EntityCoin;
 
 public class RenderCoin extends Render {
 

--- a/client/RenderKakejiku.java
+++ b/client/RenderKakejiku.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
@@ -6,8 +6,11 @@ import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+
+import wa.*;
 
 public class RenderKakejiku extends Render {
 

--- a/client/RenderKotoBlock.java
+++ b/client/RenderKotoBlock.java
@@ -1,0 +1,117 @@
+package wa.client;
+
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.entity.Entity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.ResourceLocation;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import wa.*;
+import wa.block.Blocks;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class RenderKotoBlock extends TileEntitySpecialRenderer {
+	
+	private static final ResourceLocation thisTex = new ResourceLocation("wa:textures/entity/koto_model.png");
+    public static RenderKotoBlock thisRenderer;
+    private ModelKoto thisModel = new ModelKoto();
+    
+    public void renderTileEntityThisAt(TileEntityKoto par1Tile, double par2, double par4, double par6, float par8)
+    {
+        this.setRotation(par1Tile, (float)par2, (float)par4, (float)par6);
+    }
+    
+    public void setTileEntityRenderer(TileEntityRendererDispatcher par1TileEntityRenderer)
+    {
+        super.func_147497_a(par1TileEntityRenderer);
+        thisRenderer = this;
+    }
+    
+    public void setRotation(TileEntityKoto par0Tile, float par1, float par2, float par3)
+    {
+    	byte l = (byte)par0Tile.getBlockMetadata();
+    	
+    	float f = 0.0F;
+    	switch(l)
+    	{
+    	case 0:
+    		f = 180.0F;
+    		break;
+    	case 1:
+    		f = -90.0F;
+    		break;
+    	case 2:
+    		f = 0.0F;
+    		break;
+    	case 3:
+    		f = 90.0F;
+    		break;
+    		default:
+    			break;
+    	}
+    	
+    	this.bindTexture(this.thisTex);
+        
+        GL11.glPushMatrix();
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glTranslatef((float)par1 + 0.5F, (float)par2 + 1.5F, (float)par3 + 0.5F);
+        GL11.glScalef(1.0F, -1.0F, -1.0F);
+        GL11.glRotatef(f, 0.0F, 1.0F, 0.0F);
+        thisModel.render((Entity)null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0625F);
+        
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glPopMatrix(); 
+        
+        
+        Tessellator tessellator = Tessellator.instance;
+        
+        GL11.glPushMatrix();
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        GL11.glColor4f(2.0F, 2.0F, 2.0F, 1.0F);
+        GL11.glTranslatef((float)par1 + 0.5F, (float)par2 + 0.5F, (float)par3 + 0.5F);
+        GL11.glScalef(1.0F, -1.0F, -1.0F);
+        GL11.glRotatef(f, 0.0F, 1.0F, 0.0F);
+        
+        IIcon iicon = Blocks.koto.getIcon(1, 4);
+        float f14 = iicon.getMinU();
+        float f15 = iicon.getMaxU();
+        float f4 = iicon.getMinV();
+        float f5 = iicon.getMaxV();
+        this.bindTexture(TextureMap.locationBlocksTexture);
+        
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(1.0F, 1.0F, 1.0F);
+        tessellator.addVertexWithUV(-0.7D, 0.175D, -0.3D, (double)f15, (double)f4);
+        tessellator.addVertexWithUV(0.75D, 0.225D, -0.3D, (double)f14, (double)f4);
+        tessellator.addVertexWithUV(0.75D, 0.225D, 0.3D, (double)f14, (double)f5);
+        tessellator.addVertexWithUV(-0.7D, 0.175D, 0.3D, (double)f15, (double)f5);
+        tessellator.draw();
+        
+        tessellator.startDrawingQuads();
+        tessellator.setNormal(1.0F, 1.0F, 1.0F);
+        tessellator.addVertexWithUV(0.7D, 0.225D, -0.3D, (double)f15, (double)f4);
+        tessellator.addVertexWithUV(1.05D, 0.3D, -0.3D, (double)f14, (double)f4);
+        tessellator.addVertexWithUV(1.05D, 0.3D, 0.3D, (double)f14, (double)f5);
+        tessellator.addVertexWithUV(0.7D, 0.225D, 0.3D, (double)f15, (double)f5);
+        tessellator.draw();
+        
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glPopMatrix();
+    }
+    
+    public void renderTileEntityAt(TileEntity par1TileEntity, double par2, double par4, double par6, float par8)
+    {
+        this.renderTileEntityThisAt((TileEntityKoto)par1TileEntity, par2, par4, par6, par8);
+    }
+
+}

--- a/client/RenderNorenBlock.java
+++ b/client/RenderNorenBlock.java
@@ -1,13 +1,13 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
-import wa.block.BlockCharm;
+import wa.block.BlockNoren;
 
-public class RenderCharmBlock implements ISimpleBlockRenderingHandler {
+public class RenderNorenBlock implements ISimpleBlockRenderingHandler {
 
 	@Override
 	public void renderInventoryBlock(Block block, int metadata, int modelID,
@@ -42,7 +42,7 @@ public class RenderCharmBlock implements ISimpleBlockRenderingHandler {
 
 	@Override
 	public int getRenderId() {
-		return BlockCharm.renderID;
+		return BlockNoren.renderID;
 	}
 
 }

--- a/client/RenderObon.java
+++ b/client/RenderObon.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
@@ -11,8 +11,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Direction;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+
+import wa.EntityObon;
 
 public class RenderObon extends Render {
 

--- a/client/RenderShuriken.java
+++ b/client/RenderShuriken.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import net.minecraft.client.Minecraft;
@@ -6,8 +6,11 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
+
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
+
+import wa.EntityShuriken;
 
 public class RenderShuriken extends Render {
 

--- a/client/RenderSusuki.java
+++ b/client/RenderSusuki.java
@@ -1,0 +1,78 @@
+package wa.client;
+
+import wa.block.BlockSusuki;
+import wa.block.Blocks;
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+
+public class RenderSusuki extends RenderingBase {
+	
+	private IIcon[] top;
+	private IIcon[] middle;
+	private IIcon bottom;
+
+	@Override
+	public void renderInventoryBlock(Block block, int metadata, int modelID,
+			RenderBlocks renderer) {
+	}
+
+	@Override
+	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z,
+			Block block, int modelId, RenderBlocks renderer) {
+		top = new IIcon[] {Blocks.susuki.getIcon(0, 0), Blocks.susuki.getIcon(3, 0), Blocks.susuki.getIcon(4, 0)};
+		middle = new IIcon[] {Blocks.susuki.getIcon(1, 0), Blocks.susuki.getIcon(1, 0), Blocks.susuki.getIcon(5, 0)};
+		bottom = Blocks.susuki.getIcon(2, 0);
+		
+		int cood = (x + z) & 3;
+		if (cood > 2) cood = 2; 
+		float ajust = cood == 1 ? 1.0F : (cood == 2 ? -1.0F : 0.0F);
+		
+		if (modelId == this.getRenderId()) {
+			boolean connectTop = world.getBlock(x, y + 1, z) == Blocks.susuki;
+			boolean connectBottom = world.getBlock(x, y - 1, z) == Blocks.susuki;
+			
+			if (connectTop) {
+				if (connectBottom) {
+					
+					renderer.setOverrideBlockTexture(middle[cood]);
+					block.setBlockBounds(ajust/16.0F, 0.0F/16.0F, ajust/16.0F, (16.0F + ajust)/16.0F, 16.0F/16.0F, (16.0F + ajust)/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderCrossedSquares(block, x, y, z);
+				}
+				else {
+					
+					renderer.setOverrideBlockTexture(bottom);
+					block.setBlockBounds(ajust/16.0F, 0.0F/16.0F, ajust/16.0F, (16.0F + ajust)/16.0F, 16.0F/16.0F, (16.0F + ajust)/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderCrossedSquares(block, x, y, z);
+				}
+			}
+			else {
+				renderer.setOverrideBlockTexture(top[cood]);
+				block.setBlockBounds(ajust/16.0F, 0.0F/16.0F, ajust/16.0F, (16.0F + ajust)/16.0F, 16.0F/16.0F, (16.0F + ajust)/16.0F);
+				renderer.setRenderBoundsFromBlock(block);
+				renderer.renderCrossedSquares(block, x, y, z);
+			}
+			
+			renderer.clearOverrideBlockTexture();
+			block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+			renderer.setRenderBoundsFromBlock(block);
+			return true;
+		}
+		
+		return false;
+	}
+
+	@Override
+	public boolean shouldRender3DInInventory(int a) {
+		return false;
+	}
+
+	@Override
+	public int getRenderId() {
+		return BlockSusuki.renderID;
+	}
+
+}

--- a/client/RenderUmeLog.java
+++ b/client/RenderUmeLog.java
@@ -1,0 +1,188 @@
+package wa.client;
+
+import wa.block.BlockUmeWood;
+import wa.block.Blocks;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class RenderUmeLog extends RenderingBase {
+	
+	private IIcon leavesIcon;
+	private IIcon woodIcon;
+
+	@Override
+	public void renderInventoryBlock(Block block, int metadata, int modelID,
+			RenderBlocks renderer) {
+		this.woodIcon = Blocks.umeLog.getIcon(1, 0);
+		this.leavesIcon = Blocks.umeLog.getIcon(2, 0);
+		
+		if (modelID == this.getRenderId())
+		{
+			//box
+			renderInvCuboid(renderer, block,  1.0F/16.0F, 2.0F/16.0F, 1.0F/16.0F, 15.0F/16.0F, 15.0F/16.0F, 15.0F/16.0F,  this.leavesIcon);
+			renderInvCuboid(renderer, block,  6.0F/16.0F, 0.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F,  this.woodIcon);
+		}
+	}
+
+	@Override
+	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z,
+			Block block, int modelId, RenderBlocks renderer) {
+		this.woodIcon = Blocks.umeLog.getIcon(1, 0);
+		this.leavesIcon = Blocks.umeLog.getIcon(2, 0);
+		int meta = world.getBlockMetadata(x, y, z);
+		
+		if (modelId == this.getRenderId()) {
+			
+			int[] conected = {0,0,0,0,0,0};
+			int conectSize = 0;
+			
+			//各方向の接続を確認
+			for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+				Block get = world.getBlock(x + dir.offsetX, y + dir.offsetY, z + dir.offsetZ);
+				if (get == block || get.getMaterial() == Material.ground || get.getMaterial() == Material.grass) {
+					conected[dir.ordinal()] = 1;
+					conectSize++;
+				}
+			}
+			
+			//metadata 1以上にすると、強制的に花になる
+			if (conectSize < 2 || meta > 0)
+			{
+				renderer.setOverrideBlockTexture(this.leavesIcon);
+				block.setBlockBounds(0.0F/16.0F, 0.0F/16.0F, 0.0F/16.0F, 16.0F/16.0F, 16.0F/16.0F, 16.0F/16.0F);
+				renderer.setRenderBoundsFromBlock(block);
+				renderer.renderCrossedSquares(block, x, y, z);
+				
+				renderer.setOverrideBlockTexture(this.woodIcon);
+				block.setBlockBounds(7.0F/16.0F, 7.0F/16.0F, 7.0F/16.0F, 9.0F/16.0F, 9.0F/16.0F, 9.0F/16.0F);
+				renderer.setRenderBoundsFromBlock(block);
+				renderer.renderStandardBlock(block, x, y, z);
+				
+				/* 接続条件にあわせて接続部分の描画。ゴリ押し実装… */
+				
+				if (conected[0] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(6.0F/16.0F, 0.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[1] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(6.0F/16.0F, 10.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F, 16.0F/16.0F, 10.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[2] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(6.0F/16.0F, 6.0F/16.0F, 0.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F, 6.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				if (conected[3] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(6.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F, 16.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[4] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(0.0F/16.0F, 6.0F/16.0F, 6.0F/16.0F, 6.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[5] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(10.0F/16.0F, 6.0F/16.0F, 6.0F/16.0F, 16.0F/16.0F, 10.0F/16.0F, 10.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+			}
+			else
+			{
+				renderer.setOverrideBlockTexture(this.woodIcon);
+				block.setBlockBounds(4.0F/16.0F, 4.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F);
+				renderer.setRenderBoundsFromBlock(block);
+				renderer.renderStandardBlock(block, x, y, z);
+				
+				if (conected[0] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(4.0F/16.0F, 0.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[1] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(4.0F/16.0F, 12.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F, 16.0F/16.0F, 12.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[2] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(4.0F/16.0F, 4.0F/16.0F, 0.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F, 4.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				if (conected[3] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(4.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F, 16.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[4] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(0.0F/16.0F, 4.0F/16.0F, 4.0F/16.0F, 4.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+				
+				if (conected[5] == 1)
+				{
+					renderer.setOverrideBlockTexture(this.woodIcon);
+					block.setBlockBounds(12.0F/16.0F, 4.0F/16.0F, 4.0F/16.0F, 16.0F/16.0F, 12.0F/16.0F, 12.0F/16.0F);
+					renderer.setRenderBoundsFromBlock(block);
+					renderer.renderStandardBlock(block, x, y, z);
+				}
+			}
+			
+			renderer.clearOverrideBlockTexture();
+			block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+			renderer.setRenderBoundsFromBlock(block);
+			return true;
+		}
+		
+		return false;
+	}
+
+	@Override
+	public boolean shouldRender3DInInventory(int a) {
+		return true;
+	}
+
+	@Override
+	public int getRenderId() {
+		return BlockUmeWood.renderID;
+	}
+
+}

--- a/client/RenderUmeWood.java
+++ b/client/RenderUmeWood.java
@@ -1,4 +1,4 @@
-package wa;
+package wa.client;
 
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;

--- a/client/RenderZabutonBlock.java
+++ b/client/RenderZabutonBlock.java
@@ -1,0 +1,60 @@
+package wa.client;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+
+import wa.*;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.entity.Entity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class RenderZabutonBlock extends TileEntitySpecialRenderer {
+	
+	private static final ResourceLocation thisTex = new ResourceLocation("wa:textures/entity/zabuton_model.png");
+	private static final ResourceLocation altTex = new ResourceLocation("wa:textures/entity/zabuton_model_alt.png");
+    public static RenderZabutonBlock thisRenderer;
+    private ModelZabuton thisModel = new ModelZabuton();
+    
+    public void renderTileEntityThisAt(TileEntityZabuton par1Tile, double par2, double par4, double par6, float par8)
+    {
+        this.setRotation(par1Tile, (float)par2, (float)par4, (float)par6);
+    }
+    
+    public void setTileEntityRenderer(TileEntityRendererDispatcher par1TileEntityRenderer)
+    {
+        super.func_147497_a(par1TileEntityRenderer);
+        thisRenderer = this;
+    }
+    
+    public void setRotation(TileEntityZabuton par0Tile, float par1, float par2, float par3)
+    {
+    	byte l = (byte)par0Tile.getBlockMetadata();
+    	boolean alt = (l & 8) != 0;
+    	byte size = (byte) (l & 7);
+    	
+    	this.bindTexture(alt ? this.altTex : this.thisTex);
+        
+        GL11.glPushMatrix();
+        GL11.glEnable(GL12.GL_RESCALE_NORMAL);
+        
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glTranslatef((float)par1 + 0.5F, (float)par2 + 1.5F, (float)par3 + 0.5F);
+        GL11.glScalef(1.0F, -1.0F, -1.0F);
+        GL11.glRotatef(0.0F, 0.0F, 0.0F, 0.0F);
+        thisModel.render((Entity)null, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0625F, size);
+        
+        GL11.glDisable(GL12.GL_RESCALE_NORMAL);
+        GL11.glPopMatrix(); 
+    }
+    
+    public void renderTileEntityAt(TileEntity par1TileEntity, double par2, double par4, double par6, float par8)
+    {
+        this.renderTileEntityThisAt((TileEntityZabuton)par1TileEntity, par2, par4, par6, par8);
+    }
+
+}

--- a/client/RenderZabutonEntity.java
+++ b/client/RenderZabutonEntity.java
@@ -1,0 +1,36 @@
+package wa.client;
+
+import wa.EntityZabuton;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ResourceLocation;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+/**
+ * 何も描画しない透明Entityのためのクラス
+ * @author defeatedcrow
+ */
+@SideOnly(Side.CLIENT)
+public class RenderZabutonEntity extends Render
+{
+	//仮
+	private static final ResourceLocation tex = new ResourceLocation("wa:textures/entity/zabuton.png");
+
+	@Override
+	public void doRender(Entity par1Entity, double par2, double par4, double par6, float par8, float par9)
+	{
+		//なにもしない
+	}
+	
+	protected ResourceLocation getStunTextures(EntityZabuton par1Entity)
+    {
+        return tex;
+    }
+
+	@Override
+	protected ResourceLocation getEntityTexture(Entity entity) {
+		return this.getStunTextures((EntityZabuton)entity);
+	}
+
+}

--- a/client/RenderingBase.java
+++ b/client/RenderingBase.java
@@ -1,0 +1,67 @@
+package wa.client;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
+
+import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public abstract class RenderingBase implements ISimpleBlockRenderingHandler {
+	
+	public abstract void renderInventoryBlock(Block block, int metadata, int modelID,
+			RenderBlocks renderer);
+
+	public abstract boolean renderWorldBlock(IBlockAccess world, int x, int y, int z,
+			Block block, int modelId, RenderBlocks renderer);
+
+	public abstract boolean shouldRender3DInInventory(int a);
+
+	public abstract int getRenderId();
+	
+	//original code was made by regin666
+	protected void renderInvCuboid(RenderBlocks renderer, Block block, float minX, float minY, float minZ, float maxX, float maxY, float maxZ, IIcon icon)
+	{
+		Tessellator tessellator = Tessellator.instance;
+		block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+		renderer.setRenderBoundsFromBlock(block);
+		GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
+		block.setBlockBounds(minX, minY, minZ, maxX, maxY, maxZ);
+		renderer.setRenderBoundsFromBlock(block);
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(0.0F, -1F, 0.0F);
+		renderer.renderFaceYNeg(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(0.0F, 1.0F, 0.0F);
+		renderer.renderFaceYPos(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(0.0F, 0.0F, -1F);
+		renderer.renderFaceXPos(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(0.0F, 0.0F, 1.0F);
+		renderer.renderFaceXNeg(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(-1F, 0.0F, 0.0F);
+		renderer.renderFaceZNeg(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		tessellator.startDrawingQuads();
+		tessellator.setNormal(1.0F, 0.0F, 0.0F);
+		renderer.renderFaceZPos(block, 0.0D, 0.0D, 0.0D, icon);
+		tessellator.draw();
+		GL11.glTranslatef(0.5F, 0.5F, 0.5F);
+		block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+		renderer.setRenderBoundsFromBlock(block);
+	}
+}


### PR DESCRIPTION
- change : 琴にModelの追加、TileEntity化(ModelKoto)
- change : 梅の原木にISBRH実装レンダークラス追加(RenderUmeLog)、スニークしながら設置すると常に花ブロックになる機能追加
- change : 畳の継承する半ブロックベースクラスを独自のものに差し替え、設置向きによってブロックの向きが変わる機能追加
- change : 座布団のTileEntity化と、騎乗用のダミーEntity追加、重ねて設置できる機能を追加
- change : テクスチャの変更(太鼓、稲、ススキ)
- change : client onlyクラスのパッケージ変更
- ex : 補助用のベースクラスを幾つか追加
